### PR TITLE
Build docs manually

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yml
+++ b/.github/workflows/build_and_deploy_docs.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         pip install .
         pip install -r docs/requirements.txt
-        sphinx-build docs ./docs/_build/html
+        sphinx-build docs/source ./docs/_build/html
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML

--- a/.github/workflows/build_and_deploy_docs.yml
+++ b/.github/workflows/build_and_deploy_docs.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML
-        path: docs/build/html
+        path: docs/_build/html
     - name: Commit documentation changes
       run: |
         git clone https://github.com/BCCDC-PHL/tb-db.git --branch gh-pages --single-branch gh-pages

--- a/.github/workflows/build_and_deploy_docs.yml
+++ b/.github/workflows/build_and_deploy_docs.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: directly build sphinx
       run: |
-        pip install -r requirements.txt
+        pip install .
         pip install -r docs/requirements.txt
         sphinx-build docs ./docs/_build/html
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/build_and_deploy_docs.yml
+++ b/.github/workflows/build_and_deploy_docs.yml
@@ -10,10 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        build-command: "make html"
-        docs-folder: "docs"
+    - name: directly build sphinx
+      run: |
+        pip install -r requirements.txt
+        pip install -r docs/requirements.txt
+        sphinx-build docs ./docs/_build/html
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML
@@ -21,7 +22,7 @@ jobs:
     - name: Commit documentation changes
       run: |
         git clone https://github.com/BCCDC-PHL/tb-db.git --branch gh-pages --single-branch gh-pages
-        cp -r docs/build/html/* gh-pages/
+        cp -r docs/_build/html/* gh-pages/
         cd gh-pages
         touch .nojekyll
         git config --local user.email "action@github.com"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-file:///github/workspace --no-index
 sphinx==5.3.0
 sphinx-rtd-theme==1.1.1


### PR DESCRIPTION
The [sphinx-action](https://github.com/ammaraskar/sphinx-action) that we were using to build the docs uses an old version of python that doesn't recognize the new style of type annotations. We'll just build manually.

Fixes #9 