### PR TITLE
Sideline `HistoryMixin` functionality and split Sample/Cluster relationships into separate tables

### DIFF
--- a/scripts/load_cgmlst.py
+++ b/scripts/load_cgmlst.py
@@ -33,7 +33,7 @@ def main(args):
         sample = session.scalars(stmt).one()
         print("Created profile for sample: " + sample.sample_id)
         print("Updating Parent links..")
-        crud.update_link_foreign_keys(session,sample.sample_id, MiruProfile,Sample)
+        #crud.update_link_foreign_keys(session,sample.sample_id, MiruProfile,Sample)
 
 
 if __name__ == '__main__':

--- a/scripts/load_cgmlst.py
+++ b/scripts/load_cgmlst.py
@@ -11,6 +11,7 @@ import tb_db.parsers as parsers
 import tb_db.crud as crud
 
 from tb_db.models import Sample
+from tb_db.models import MiruProfile
 
 
 def main(args):
@@ -31,6 +32,8 @@ def main(args):
         stmt = select(Sample).where(Sample.id == profile.sample_id)
         sample = session.scalars(stmt).one()
         print("Created profile for sample: " + sample.sample_id)
+        print("Updating Parent links..")
+        crud.update_link_foreign_keys(session,sample.sample_id, MiruProfile,Sample)
 
 
 if __name__ == '__main__':

--- a/scripts/load_cgmlst.py
+++ b/scripts/load_cgmlst.py
@@ -23,8 +23,6 @@ def main(args):
     session = Session()
 
     cgmlst_by_sample_id = parsers.parse_cgmlst(args.input)
-    # print(json.dumps(cgmlst_by_sample_id, indent=2))
-    # exit()
     cgmlst_profiles = list(cgmlst_by_sample_id.values())
     created_profiles = crud.create_cgmlst_allele_profiles(session, cgmlst_profiles)
 

--- a/scripts/load_cgmlst_cluster.py
+++ b/scripts/load_cgmlst_cluster.py
@@ -24,16 +24,10 @@ def main(args):
     session = Session()
 
     cgmlst_cluster_by_sample = parsers.parse_cgmlst_cluster(args.input)
-    # print(json.dumps(cgmlst_by_sample_id, indent=2))
-    # exit()
-    #cgmlst_profiles = list(cgmlst_by_sample_id.values())
     created_cgmlst_clusters = crud.add_samples_to_cgmlst_clusters(session, cgmlst_cluster_by_sample)
 
     for sample in created_cgmlst_clusters:
         print("added cluster to sample: " + sample.sample_id)
-        #print("Updating Parent links..")
-        #crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
-        #crud.update_link_foreign_keys(session,sample.sample_id, MiruProfile,Sample)
 
 
 

--- a/scripts/load_cgmlst_cluster.py
+++ b/scripts/load_cgmlst_cluster.py
@@ -11,6 +11,8 @@ import tb_db.parsers as parsers
 import tb_db.crud as crud
 
 from tb_db.models import Sample
+from tb_db.models import CgmlstAlleleProfile
+from tb_db.models import MiruProfile
 
 
 def main(args):
@@ -26,6 +28,12 @@ def main(args):
     # exit()
     #cgmlst_profiles = list(cgmlst_by_sample_id.values())
     created_cgmlst_clusters = crud.add_samples_to_cgmlst_clusters(session, cgmlst_cluster_by_sample)
+
+    for sample in created_cgmlst_clusters:
+        print("added cluster to sample: " + sample.sample_id)
+        print("Updating Parent links..")
+        crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
+        crud.update_link_foreign_keys(session,sample.sample_id, MiruProfile,Sample)
 
 
 

--- a/scripts/load_cgmlst_cluster.py
+++ b/scripts/load_cgmlst_cluster.py
@@ -31,9 +31,9 @@ def main(args):
 
     for sample in created_cgmlst_clusters:
         print("added cluster to sample: " + sample.sample_id)
-        print("Updating Parent links..")
-        crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
-        crud.update_link_foreign_keys(session,sample.sample_id, MiruProfile,Sample)
+        #print("Updating Parent links..")
+        #crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
+        #crud.update_link_foreign_keys(session,sample.sample_id, MiruProfile,Sample)
 
 
 

--- a/scripts/load_cgmlst_cluster.py
+++ b/scripts/load_cgmlst_cluster.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import argparse
+import csv
+import json
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+import tb_db.parsers as parsers
+import tb_db.crud as crud
+
+from tb_db.models import Sample
+
+
+def main(args):
+    with open(args.config, 'r') as f:
+        config = json.load(f)
+    connection_uri = config['connection_uri']
+    engine = create_engine(connection_uri)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    cgmlst_cluster_by_sample = parsers.parse_cgmlst_cluster(args.input)
+    # print(json.dumps(cgmlst_by_sample_id, indent=2))
+    # exit()
+    #cgmlst_profiles = list(cgmlst_by_sample_id.values())
+    created_cgmlst_clusters = crud.add_samples_to_cgmlst_clusters(session, cgmlst_cluster_by_sample)
+
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input')
+    parser.add_argument('-c', '--config', help="config file (JSON format))")
+    args = parser.parse_args()
+    main(args)

--- a/scripts/load_miru.py
+++ b/scripts/load_miru.py
@@ -22,22 +22,14 @@ def main(args):
     session = Session()
 
     miru_profiles_by_sample_id = parsers.parse_miru(args.input)
-    # print(json.dumps(miru_profiles_by_sample_id, indent=2))
-    # exit()
     
     created_profiles = crud.create_miru_profiles(session, miru_profiles_by_sample_id)
     
-    # created_profiles = []
-    # for sample_id, miru_profile in miru_profiles_by_sample_id.items():
-    #     created_profile = crud.create_miru_profile(session, sample_id, miru_profile)
-    #     if created_profile is not None:
-    #         created_profiles.append(created_profile)
 
     for profile in created_profiles:
         stmt = select(Sample).where(Sample.id == profile.sample_id)
         sample = session.scalars(stmt).one()
         print("Created profile for sample: " + sample.sample_id)
-        #crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
 
 
 if __name__ == '__main__':

--- a/scripts/load_miru.py
+++ b/scripts/load_miru.py
@@ -37,7 +37,7 @@ def main(args):
         stmt = select(Sample).where(Sample.id == profile.sample_id)
         sample = session.scalars(stmt).one()
         print("Created profile for sample: " + sample.sample_id)
-        crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
+        #crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
 
 
 if __name__ == '__main__':

--- a/scripts/load_miru.py
+++ b/scripts/load_miru.py
@@ -10,7 +10,7 @@ import tb_db.parsers as parsers
 import tb_db.crud as crud
 
 from tb_db.models import Sample
-
+from tb_db.models import CgmlstAlleleProfile
     
 def main(args):
 
@@ -37,6 +37,7 @@ def main(args):
         stmt = select(Sample).where(Sample.id == profile.sample_id)
         sample = session.scalars(stmt).one()
         print("Created profile for sample: " + sample.sample_id)
+        crud.update_link_foreign_keys(session,sample.sample_id, CgmlstAlleleProfile,Sample)
 
 
 if __name__ == '__main__':

--- a/tb_db/crud.py
+++ b/tb_db/crud.py
@@ -410,7 +410,7 @@ def add_samples_to_cgmlst_clusters(db: Session, cgmlst_cluster: list[dict[str, o
             db_samples.append(sample)
             db.commit()
             db.refresh(sample)
-            
+
 
     #select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
     #sample = db.scalars(select_sample_stmt).one()

--- a/tb_db/crud.py
+++ b/tb_db/crud.py
@@ -234,13 +234,6 @@ def create_miru_profile(db: Session, sample_id: str, miru_profile: dict[str, obj
     select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
     sample = db.scalars(select_sample_stmt).one()
     sample.miru_cluster.append(db_miru_cluster)
-    #sample_miru_cluster = SampleMiruCluster(
-    #    sample_id = sample.id,
-    #    cluster_id = db_miru_cluster.id
-
-    #)
-
-    #db.add(sample_miru_cluster)
     db.commit()
 
     select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
@@ -322,7 +315,6 @@ def create_miru_profiles(db: Session, miru_profiles_by_sample_id: dict[str, obje
                 sample_id = sample_id,
                 accession = miru_profile['accession'],
                 collection_date = miru_profile['collection_date']
-                #miru_cluster_id = db_miru_cluster.id,
             )
             db.add(db_sample)
             db.commit()
@@ -389,7 +381,6 @@ def get_miru_cluster_by_sample_id(db: Session, sample_id: str):
         code = db.query(MiruCluster).get(miru_cluster_id).cluster_id
         miru_cluster_code.append(code)
 
-
     return miru_cluster_code
 
 
@@ -411,7 +402,6 @@ def add_samples_to_cgmlst_clusters(db: Session, cgmlst_cluster: list[dict[str, o
     existing_cgmlst_clusters = db.query(CgmlstCluster).all()
     existing_cgmlst_cluster_ids = set([cluster.cluster_id for cluster in existing_cgmlst_clusters])
 
-    #cluster_id = cgmlst_cluster['cluster']
     db_samples = []
     added_cgmlst_cluster_ids = set()
     for row in cgmlst_cluster:
@@ -431,23 +421,12 @@ def add_samples_to_cgmlst_clusters(db: Session, cgmlst_cluster: list[dict[str, o
         else:
             select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
             sample = db.scalars(select_sample_stmt).one()
-            #sample.cgmlst_cluster.append(db_cgmlst_cluster)
-            #cgmlst_sample_cluster = SampleCgmlstCluster(
-            #    sample_id = sample.id,
-            #    cluster_id = db_cgmlst_cluster.id
         
         sample.cgmlst_cluster.append(db_cgmlst_cluster)
         db.add(sample,db_cgmlst_cluster)
         db_samples.append(sample)
         db.commit()
-            #db_samples.append(sample)
-            #db.add(cgmlst_sample_cluster)
-            #db.commit()
-      
 
-
-    #select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
-    #sample = db.scalars(select_sample_stmt).one()
     return db_samples
 
 ### cgmlst
@@ -472,19 +451,15 @@ def add_sample_to_cgmlst_cluster(db: Session, sample_id: str, cgmlst_cluster: di
 
     if sample_id not in existing_sample_ids:
         logging.warning('cannot add cgmlst cluster for a sample that does not exist...')
+
         return None
 
     else:
         select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
         sample = db.scalars(select_sample_stmt).one()
-        #sample.cgmlst_cluster_id = db_cgmlst_cluster.id
         sample.cgmlst_cluster.append(db_cgmlst_cluster)
-        #cgmlst_sample_cluster = SampleCgmlstCluster(
-        #        sample_id = sample.id,
-        #        cluster_id = db_cgmlst_cluster.id
-        #)
-        #db.add(cgmlst_sample_cluster)
         db.commit()
+
         return sample
 
 

--- a/tb_db/crud.py
+++ b/tb_db/crud.py
@@ -351,11 +351,11 @@ def get_miru_cluster_by_sample_id(db: Session, sample_id: str):
         Sample.sample_id == sample_id
     )
 
-    miru_ids = []
+    sample_dicts = []
     for row in query_result:
-        miru_ids.append(utils.row2dict(row))
+        sample_dicts.append(utils.row2dict(row))
     
-    for item in miru_ids:
+    for item in sample_dicts:
         if item['valid_until'] is None:
             miru_cluster_id = item['miru_cluster_id']
 
@@ -409,6 +409,7 @@ def add_samples_to_cgmlst_clusters(db: Session, cgmlst_cluster: list[dict[str, o
             sample.cgmlst_cluster_id = db_cgmlst_cluster.id
             db_samples.append(sample)
             db.commit()
+            db.refresh(sample)
             
 
     #select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
@@ -453,11 +454,11 @@ def get_cgmlst_cluster_by_sample_id(db: Session, sample_id: str):
         Sample.sample_id == sample_id
     )
 
-    cgmlst_ids = []
+    sample_dicts = []
     for row in query_result:
-        cgmlst_ids.append(utils.row2dict(row))
+        sample_dicts.append(utils.row2dict(row))
     
-    for item in cgmlst_ids:
+    for item in sample_dicts:
         if item['valid_until'] is None:
             cgmlst_cluster_id = item['cgmlst_cluster_id']
 

--- a/tb_db/crud.py
+++ b/tb_db/crud.py
@@ -89,8 +89,7 @@ def get_sample(db: Session, sample_id: str):
     :return: Current valid database record for the sample.
     :rtype: models.Sample|NoneType
     """
-    sample_record = db.query(Sample).where(and_(Sample.sample_id == sample_id,
-                                                Sample.valid_until == None)).one_or_none()
+    sample_record = db.query(Sample).where(Sample.sample_id == sample_id).one_or_none()
 
     return sample_record
 
@@ -137,7 +136,7 @@ def create_cgmlst_allele_profile(db: Session, cgmlst_allele_profile: dict[str, o
         )
         db.add(db_sample)
         db.commit()
-    stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
+    stmt = select(Sample).where(Sample.sample_id == sample_id)
     sample = db.scalars(stmt).one()
     db_cgmlst_allele_profile = CgmlstAlleleProfile(
         sample_id = sample.id,
@@ -175,7 +174,7 @@ def create_cgmlst_allele_profiles(db: Session, cgmlst_allele_profiles: list[dict
             )
             db.add(db_sample)
             db.commit()
-        stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
+        stmt = select(Sample).where(Sample.sample_id == sample_id)
         sample = db.scalars(stmt).one()
         db_cgmlst_allele_profile = CgmlstAlleleProfile(
             sample_id = sample.id,
@@ -216,29 +215,34 @@ def create_miru_profile(db: Session, sample_id: str, miru_profile: dict[str, obj
     cluster_id = miru_profile['cluster']
     if (cluster_id not in existing_miru_cluster_ids):
         db_miru_cluster = MiruCluster(
-            cluster_id = cluster_id,
+            cluster_id = cluster_id
         )
         db.add(db_miru_cluster)
         db.commit()
 
-    select_miru_cluster_stmt = select(MiruCluster).where(and_(MiruCluster.cluster_id == cluster_id, MiruCluster.valid_until == None))
+    select_miru_cluster_stmt = select(MiruCluster).where(MiruCluster.cluster_id == cluster_id)
     db_miru_cluster = db.scalars(select_miru_cluster_stmt).one()
 
     if sample_id not in existing_sample_ids:
         db_sample = Sample(
             sample_id = sample_id,
-            collection_date = miru_profile['collection_date'],
-            miru_cluster_id = db_miru_cluster.id,
+            collection_date = miru_profile['collection_date']
         )
         db.add(db_sample)
         db.commit()
-    else:
-        select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
-        sample = db.scalars(select_sample_stmt).one()
-        sample.miru_cluster_id = db_miru_cluster.id
-        db.commit()
+    
+    select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
+    sample = db.scalars(select_sample_stmt).one()
+    sample_miru_cluster = SampleMiruCluster(
+        sample_id = sample.id,
+        cluster_id = db_miru_cluster.id
 
-    select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
+    )
+
+    db.add(sample_miru_cluster)
+    db.commit()
+
+    select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
     sample = db.scalars(select_sample_stmt).one()
 
     vntr_fields = {}
@@ -261,7 +265,7 @@ def create_miru_profile(db: Session, sample_id: str, miru_profile: dict[str, obj
         profile_by_position = json.dumps(profile_by_position),
         miru_pattern = miru_profile['miru_pattern'],
     )
-    select_miru_profile_stmt = select(MiruProfile).where(and_(MiruProfile.sample_id == sample.id, MiruProfile.valid_until == None))
+    select_miru_profile_stmt = select(MiruProfile).where(MiruProfile.sample_id == sample.id)
     existing_profile_for_sample = db.scalars(select_miru_profile_stmt).one_or_none()
     if existing_profile_for_sample is not None:
         existing_profile_for_sample.percent_called = db_miru_profile.percent_called
@@ -303,32 +307,40 @@ def create_miru_profiles(db: Session, miru_profiles_by_sample_id: dict[str, obje
         cluster_id = miru_profile['cluster']
         if (cluster_id not in existing_miru_cluster_ids) and (cluster_id not in added_miru_cluster_ids):
             db_miru_cluster = MiruCluster(
-                cluster_id = cluster_id,
+                cluster_id = cluster_id
             )
             db.add(db_miru_cluster)
             db.commit()
             added_miru_cluster_ids.add(cluster_id)
         else:
-            select_miru_cluster_stmt = select(MiruCluster).where(and_(MiruCluster.cluster_id == cluster_id, MiruCluster.valid_until == None))
+            select_miru_cluster_stmt = select(MiruCluster).where(MiruCluster.cluster_id == cluster_id)
             db_miru_cluster = db.scalars(select_miru_cluster_stmt).one()
 
         if sample_id not in existing_sample_ids:
             db_sample = Sample(
                 sample_id = sample_id,
                 accession = miru_profile['accession'],
-                collection_date = miru_profile['collection_date'],
-                miru_cluster_id = db_miru_cluster.id,
+                collection_date = miru_profile['collection_date']
+                #miru_cluster_id = db_miru_cluster.id,
             )
             db.add(db_sample)
             db.commit()
         else:
-            select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
+            select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
             sample = db.scalars(select_sample_stmt).one()
-            sample.miru_cluster_id = db_miru_cluster.id
-            db.commit()
+            #sample.miru_cluster_id = db_miru_cluster.id
+            
 
-        select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
+        select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
         sample = db.scalars(select_sample_stmt).one()
+
+        sample_miru_cluster = SampleMiruCluster(
+        sample_id = sample.id,
+        cluster_id = db_miru_cluster.id
+
+        )
+        db.add(sample_miru_cluster)
+        db.commit()
 
         vntr_fields = {}
         for k, v in miru_profile.items():
@@ -350,7 +362,7 @@ def create_miru_profiles(db: Session, miru_profiles_by_sample_id: dict[str, obje
             profile_by_position = json.dumps(profile_by_position),
             miru_pattern = miru_profile['miru_pattern']
         )
-        select_miru_profile_stmt = select(MiruProfile).where(and_(MiruProfile.sample_id == sample.id, MiruProfile.valid_until == None))
+        select_miru_profile_stmt = select(MiruProfile).where(MiruProfile.sample_id == sample.id)
         existing_profile_for_sample = db.scalars(select_miru_profile_stmt).one_or_none()
         if existing_profile_for_sample is not None:
             existing_profile_for_sample.percent_called = db_miru_profile.percent_called
@@ -377,18 +389,17 @@ def get_miru_cluster_by_sample_id(db: Session, sample_id: str):
     query_result = db.query(Sample).filter(
         Sample.sample_id == sample_id
     )
+    id = query_result.one_or_none().id
 
-    sample_dicts = []
-    for row in query_result:
-        sample_dicts.append(utils.row2dict(row))
-    
-    for item in sample_dicts:
-        if item['valid_until'] is None:
-            miru_cluster_id = item['miru_cluster_id']
+ 
+    query_result = db.query(SampleMiruCluster).filter(
+        SampleMiruCluster.sample_id == id
+    )
 
-    query_result = db.query(MiruCluster).get(miru_cluster_id)
     
-    miru_cluster_code = utils.row2dict(query_result)['cluster_id']
+    miru_cluster_id = query_result.one_or_none().cluster_id
+    
+    miru_cluster_code = db.query(MiruCluster).get(miru_cluster_id).cluster_id
 
     return miru_cluster_code
 
@@ -421,22 +432,27 @@ def add_samples_to_cgmlst_clusters(db: Session, cgmlst_cluster: list[dict[str, o
         cluster_id = row['cluster']
         if (cluster_id not in existing_cgmlst_cluster_ids) and (cluster_id not in added_cgmlst_cluster_ids):
             db_cgmlst_cluster = CgmlstCluster(
-                cluster_id = cluster_id,
+                cluster_id = cluster_id
             )
             db.add(db_cgmlst_cluster)
             db.commit()
             added_cgmlst_cluster_ids.add(cluster_id)
-        select_cgmlst_cluster_stmt = select(CgmlstCluster).where(and_(CgmlstCluster.cluster_id == cluster_id, CgmlstCluster.valid_until == None))
+        select_cgmlst_cluster_stmt = select(CgmlstCluster).where(CgmlstCluster.cluster_id == cluster_id)
         db_cgmlst_cluster = db.scalars(select_cgmlst_cluster_stmt).one()
         if sample_id not in existing_sample_ids:
             logging.warning('cannot add cgmlst cluster for a sample that does not exist...')         
         else:
-            select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
+            select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
             sample = db.scalars(select_sample_stmt).one()
-            sample.cgmlst_cluster_id = db_cgmlst_cluster.id
+            #sample.cgmlst_cluster_id = db_cgmlst_cluster.id
+            cgmlst_sample_cluster = SampleCgmlstCluster(
+                sample_id = sample.id,
+                cluster_id = db_cgmlst_cluster.id
+            )
             db_samples.append(sample)
+            db.add(cgmlst_sample_cluster)
             db.commit()
-            db.refresh(sample)
+            #db.refresh()
 
 
     #select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
@@ -455,12 +471,12 @@ def add_sample_to_cgmlst_cluster(db: Session, sample_id: str, cgmlst_cluster: di
     cluster_id = cgmlst_cluster['cluster']
     if (cluster_id not in existing_cgmlst_cluster_ids):
         db_cgmlst_cluster = CgmlstCluster(
-            cluster_id = cluster_id,
+            cluster_id = cluster_id
         )
         db.add(db_cgmlst_cluster)
         db.commit()
 
-    select_cgmlst_cluster_stmt = select(CgmlstCluster).where(and_(CgmlstCluster.cluster_id == cluster_id, CgmlstCluster.valid_until == None))
+    select_cgmlst_cluster_stmt = select(CgmlstCluster).where(CgmlstCluster.cluster_id == cluster_id)
     db_cgmlst_cluster = db.scalars(select_cgmlst_cluster_stmt).one()
 
     if sample_id not in existing_sample_ids:
@@ -468,9 +484,14 @@ def add_sample_to_cgmlst_cluster(db: Session, sample_id: str, cgmlst_cluster: di
         return None
 
     else:
-        select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
+        select_sample_stmt = select(Sample).where(Sample.sample_id == sample_id)
         sample = db.scalars(select_sample_stmt).one()
-        sample.cgmlst_cluster_id = db_cgmlst_cluster.id
+        #sample.cgmlst_cluster_id = db_cgmlst_cluster.id
+        cgmlst_sample_cluster = SampleCgmlstCluster(
+                sample_id = sample.id,
+                cluster_id = db_cgmlst_cluster.id
+        )
+        db.add(cgmlst_sample_cluster)
         db.commit()
         return sample
 
@@ -480,39 +501,20 @@ def get_cgmlst_cluster_by_sample_id(db: Session, sample_id: str):
     query_result = db.query(Sample).filter(
         Sample.sample_id == sample_id
     )
+    id = query_result.one_or_none().id
 
-    sample_dicts = []
-    for row in query_result:
-        sample_dicts.append(utils.row2dict(row))
+ 
+    query_result = db.query(SampleCgmlstCluster).filter(
+        SampleCgmlstCluster.sample_id == id
+    )
+
     
-    for item in sample_dicts:
-        if item['valid_until'] is None:
-            cgmlst_cluster_id = item['cgmlst_cluster_id']
-
-    query_result = db.query(CgmlstCluster).get(cgmlst_cluster_id)
+    cgmlst_cluster_id = query_result.one_or_none().cluster_id
     
-    cgmlst_cluster_code = utils.row2dict(query_result)['cluster_id']
-
+    cgmlst_cluster_code = db.query(CgmlstCluster).get(cgmlst_cluster_id).cluster_id
 
 
     return cgmlst_cluster_code
 
-#update parent's link to new child id when old child is invalidated and a new child with new sample id is created
-def update_link_foreign_keys(db:Session, sampleid, parent_db, child_db):
-
-    #child samples are all samples in the samples table where sample_id is 22s393
-    all_child_sample = db.query(child_db).where(child_db.sample_id == sampleid)
-    valid_id = all_child_sample.where(child_db.valid_until==None).one_or_none().id
-    sample_dicts = []
-    for row in all_child_sample:
-        sample_dicts.append(utils.row2dict(row))
-    
-    for item in sample_dicts:
-        parent_sample = db.query(parent_db).where(parent_db.sample_id == item['id']).one_or_none()
-        if parent_sample is not None:
-            parent_sample.sample_id = valid_id
-            db.commit()
-            db.refresh(parent_sample)
-            break
 
 

--- a/tb_db/crud.py
+++ b/tb_db/crud.py
@@ -252,9 +252,6 @@ def create_miru_profile(db: Session, sample_id: str, miru_profile: dict[str, obj
     return created_miru_profile
 
 
-
-
-
 def create_miru_profiles(db: Session, miru_profiles_by_sample_id: dict[str, object]):
     """
     Create multiple MIRU profile records.
@@ -441,7 +438,7 @@ def add_sample_to_cgmlst_cluster(db: Session, sample_id: str, cgmlst_cluster: di
     if sample_id not in existing_sample_ids:
         logging.warning('cannot add cgmlst cluster for a sample that does not exist...')
         return None
-        
+
     else:
         select_sample_stmt = select(Sample).where(and_(Sample.sample_id == sample_id, Sample.valid_until == None))
         sample = db.scalars(select_sample_stmt).one()

--- a/tb_db/models.py
+++ b/tb_db/models.py
@@ -38,46 +38,6 @@ class Base:
 
 Base = declarative_base(cls=Base)
 
-
-#@declarative_mixin
-#class HistoryMixin:
-#    created_at = Column(DateTime, default=func.now())
-#    valid_until = Column(DateTime, default=None)
-#
-#    def new_version(self, session):
-#        # invalidate current version - generate an update
-#        old_id = self.id
-#        session.query(self.__class__).filter_by(id=old_id).update(
-#            values=dict(valid_until=func.now()), synchronize_session=False
-#        )
-#
-#        # make us transient (removes persistent identity)
-#        # make this an INSERT
-#        make_transient(self)
-#        self.id = None
-#
-#        # set created_at and valid_until, which means we have a new PK.
-#        self.created_at = func.now()
-#        self.valid_until = None
-
-
-#@event.listens_for(Session, "before_flush")
-#def before_flush(session, flush_context, instances):
-#    for instance in session.dirty:
-#        if not isinstance(instance):
-#            continue
-#        if not session.is_modified(instance):
-#            continue
-#
-#        if not attributes.instance_state(instance).has_identity:
-#            continue
-#
-#        # make it transient
-#        instance.new_version(session)
-#
-#        # re-add
-#        session.add(instance)
-
 association_table_cgmlst = Table(
     "association_table_cgmlst",
     Base.metadata,
@@ -99,17 +59,8 @@ class Sample(Base):
     accession = Column(String)
     collection_date = Column(Date)
 
-    #cgmlst_cluster_id = Column(
-    #    Integer,
-    #    ForeignKey("cgmlst_cluster.id"),
-    #    nullable=True,
-    #)
-    #miru_cluster_id = Column(Integer, ForeignKey("miru_cluster.id"), nullable=True)
-
     cgmlst_cluster = relationship("CgmlstCluster", secondary=association_table_cgmlst, backref = 'samples')
     miru_cluster = relationship("MiruCluster", secondary=association_table_miru, backref='samples')
-
-
 
 
 class Library(Base):
@@ -154,28 +105,7 @@ class CgmlstCluster(Base):
 
     cluster_id = Column(String)
 
-    #samples_cgmlst_cluster = relationship(
-    #    "SampleCgmlstCluster", back_populates="cgmlst_cluster", cascade="all, delete-orphan"
-    #)
-
 
 class MiruCluster(Base):
 
     cluster_id = Column(String)
-    #samples_miru_cluster = relationship(
-    #    "SampleMiruCluster", back_populates="miru_cluster", cascade="all, delete-orphan"
-    #)
-
-
-#class SampleCgmlstCluster(Base):
-#    sample_id = Column(Integer, ForeignKey("sample.id"), nullable=False)
-
-#    cluster_id = Column(Integer, ForeignKey("cgmlst_cluster.id"))
-    #cgmlst_cluster = relationship("CgmlstCluster", back_populates="sample_cgmlst_clusters")
-
-#class SampleMiruCluster(Base):
-#    sample_id = Column(Integer, ForeignKey("sample.id"), nullable=False)
-
-#    cluster_id = Column(Integer, ForeignKey("miru_cluster.id"))
-
-    #miru_cluster = relationship("MiruCluster", back_populates="sample_miru_clusters")

--- a/tb_db/models.py
+++ b/tb_db/models.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import declarative_mixin
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import make_transient
 from sqlalchemy.orm import Session
-
+from sqlalchemy import Table
 
 def camel_to_snake(s: str) -> str:
     """
@@ -61,22 +61,36 @@ Base = declarative_base(cls=Base)
 #        self.valid_until = None
 
 
-@event.listens_for(Session, "before_flush")
-def before_flush(session, flush_context, instances):
-    for instance in session.dirty:
-        if not isinstance(instance):
-            continue
-        if not session.is_modified(instance):
-            continue
+#@event.listens_for(Session, "before_flush")
+#def before_flush(session, flush_context, instances):
+#    for instance in session.dirty:
+#        if not isinstance(instance):
+#            continue
+#        if not session.is_modified(instance):
+#            continue
+#
+#        if not attributes.instance_state(instance).has_identity:
+#            continue
+#
+#        # make it transient
+#        instance.new_version(session)
+#
+#        # re-add
+#        session.add(instance)
 
-        if not attributes.instance_state(instance).has_identity:
-            continue
+association_table_cgmlst = Table(
+    "association_table_cgmlst",
+    Base.metadata,
+    Column("sample_id", ForeignKey("sample.id")),
+    Column("cgmlst_cluster_id", ForeignKey("cgmlst_cluster.id")),
+)
 
-        # make it transient
-        instance.new_version(session)
-
-        # re-add
-        session.add(instance)
+association_table_miru = Table(
+    "association_table_miru",
+    Base.metadata,
+    Column("sample_id", ForeignKey("sample.id"), primary_key=True),
+    Column("miru_cluster_id", ForeignKey("miru_cluster.id"), primary_key=True),
+)
 
 
 class Sample(Base):
@@ -92,8 +106,8 @@ class Sample(Base):
     #)
     #miru_cluster_id = Column(Integer, ForeignKey("miru_cluster.id"), nullable=True)
 
-    #cgmlst_cluster = relationship("CgmlstCluster", back_populates="samples")
-    #miru_cluster = relationship("MiruCluster", back_populates="samples")
+    cgmlst_cluster = relationship("CgmlstCluster", secondary=association_table_cgmlst, backref = 'samples')
+    miru_cluster = relationship("MiruCluster", secondary=association_table_miru, backref='samples')
 
 
 
@@ -153,15 +167,15 @@ class MiruCluster(Base):
     #)
 
 
-class SampleCgmlstCluster(Base):
-    sample_id = Column(Integer, ForeignKey("sample.id"), nullable=False)
+#class SampleCgmlstCluster(Base):
+#    sample_id = Column(Integer, ForeignKey("sample.id"), nullable=False)
 
-    cluster_id = Column(Integer, ForeignKey("cgmlst_cluster.id"))
+#    cluster_id = Column(Integer, ForeignKey("cgmlst_cluster.id"))
     #cgmlst_cluster = relationship("CgmlstCluster", back_populates="sample_cgmlst_clusters")
 
-class SampleMiruCluster(Base):
-    sample_id = Column(Integer, ForeignKey("sample.id"), nullable=False)
+#class SampleMiruCluster(Base):
+#    sample_id = Column(Integer, ForeignKey("sample.id"), nullable=False)
 
-    cluster_id = Column(Integer, ForeignKey("miru_cluster.id"))
+#    cluster_id = Column(Integer, ForeignKey("miru_cluster.id"))
 
     #miru_cluster = relationship("MiruCluster", back_populates="sample_miru_clusters")

--- a/tb_db/parsers.py
+++ b/tb_db/parsers.py
@@ -16,6 +16,21 @@ def parse_samples(samples_path):
             samples.append(sample)
 
     return samples
+    
+# cgmlst cluster
+def parse_cgmlst_cluster(samples_path):
+    samples = []
+    with open(samples_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+
+            sample = {
+                'sample_id': row['sample_id'],
+                'cluster':row['clusters_cgmlst'],
+            }
+            samples.append(sample)
+
+    return samples
 
 
 ### MIRU

--- a/tb_db/utils.py
+++ b/tb_db/utils.py
@@ -1,0 +1,15 @@
+import datetime
+import re
+
+# https://stackoverflow.com/a/1176023
+def camel_to_snake(name):
+    name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+
+# https://stackoverflow.com/a/1960546
+def row2dict(row):
+    d = {}
+    for column in row.__table__.columns:
+        d[column.name] = getattr(row, column.name)
+
+    return d

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -119,15 +119,15 @@ class TestCrudSample(unittest.TestCase):
         }
 
         created_sample = crud.create_sample(self.session, sample_dict)
-        self.assertEqual(created_sample.id,1)
+        #self.assertEqual(created_sample.id,1)
         
         result = crud.add_sample_to_cgmlst_cluster(self.session,'SAM001', cgmlst_cluster_dict)
 
         cgmlst_id = crud.get_cgmlst_cluster_by_sample_id(self.session, 'SAM001')
 
-        
+        self.assertIsNotNone(created_sample)
         self.assertEqual(cgmlst_id,'BC300')
-        self.assertEqual(result.id, 2)
+
 
     def test_get_miru_cluster(self):
         miru_dict = {
@@ -157,7 +157,7 @@ class TestCrudSample(unittest.TestCase):
         }
 
         created_sample = crud.create_sample(self.session, sample_dict)
-        self.assertEqual(created_sample.id,1)
+        #self.assertEqual(created_sample.id,1)
         
         result = crud.add_sample_to_cgmlst_cluster(self.session,'SAM001', cgmlst_cluster_dict)
 
@@ -165,7 +165,7 @@ class TestCrudSample(unittest.TestCase):
 
         
         self.assertEqual(cgmlst_id,'BC300')
-        self.assertEqual(result.id, 2)
+        #self.assertEqual(result.id, 2)
 
     def test_delete_sample(self):
         sample_dict = {
@@ -211,8 +211,8 @@ class SampleCrudMachine(RuleBasedStateMachine):
             json_serializable_sample = utils.row2dict(created_sample)
             date_fields = [
                 'collection_date',
-                'valid_until',
-                'created_at',
+                #'valid_until',
+                #'created_at',
             ]
             for date_field in date_fields: 
                 json_serializable_sample[date_field] = str(json_serializable_sample[date_field])
@@ -276,8 +276,8 @@ class CgmlstAlleleProfileCrudMachine(RuleBasedStateMachine):
             json_serializable_sample = utils.row2dict(created_sample)
             date_fields = [
                 'collection_date',
-                'valid_until',
-                'created_at',
+                #'valid_until',
+                #'created_at',
             ]
             for date_field in date_fields: 
                 json_serializable_sample[date_field] = str(json_serializable_sample[date_field])
@@ -326,13 +326,13 @@ class CgmlstAlleleProfileCrudMachine(RuleBasedStateMachine):
         
         created_cgmlst_profile = crud.create_cgmlst_allele_profile(self.session, profile_dict)
         json_serializable_cgmlst_profile = utils.row2dict(created_cgmlst_profile)
-        date_fields = [
-            'valid_until',
-            'created_at',
-        ]
-        for date_field in date_fields: 
-            json_serializable_cgmlst_profile[date_field] = str(json_serializable_cgmlst_profile[date_field])
-        log.debug("Created cgMLST Profile for sample \"" + sample_id + "\": " + json.dumps(json_serializable_cgmlst_profile))
+        #date_fields = [
+        #    'valid_until',
+        #    'created_at',
+        #]
+        #for date_field in date_fields: 
+        #    json_serializable_cgmlst_profile[date_field] = str(json_serializable_cgmlst_profile[date_field])
+        #log.debug("Created cgMLST Profile for sample \"" + sample_id + "\": " + json.dumps(json_serializable_cgmlst_profile))
 
         note(json_serializable_cgmlst_profile)
         assert(created_cgmlst_profile.sample_id == sample.id)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -43,8 +43,7 @@ class TestCrudSample(unittest.TestCase):
         sample_dict = {
             'sample_id': 'SAM001',
             'accession': 'ACC001',
-            'collection_date': datetime.date(1970, 1, 1),
-            
+            'collection_date': datetime.date(1970, 1, 1),          
         }
 
         created_sample = crud.create_sample(self.session, sample_dict)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -79,10 +79,13 @@ class TestCrudSample(unittest.TestCase):
         }
 
         created_sample = crud.create_sample(self.session, sample_dict)
-
+        self.assertEqual(created_sample.id,1)
+        
         result = crud.add_sample_to_cgmlst_cluster(self.session,'SAM001', cgmlst_cluster_dict)
 
         cgmlst_id = crud.get_cgmlst_cluster_by_sample_id(self.session, 'SAM001')
+
+        
         self.assertEqual(cgmlst_id,'BC300')
         self.assertEqual(result.id, 2)
 

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -84,6 +84,7 @@ class TestCrudSample(unittest.TestCase):
 
         cgmlst_id = crud.get_cgmlst_cluster_by_sample_id(self.session, 'SAM001')
         self.assertEqual(cgmlst_id,'BC300')
+        self.assertEqual(result.id, 2)
 
     def test_delete_sample(self):
         sample_dict = {

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -119,7 +119,7 @@ class TestCrudSample(unittest.TestCase):
         }
 
         created_sample = crud.create_sample(self.session, sample_dict)
-        #self.assertEqual(created_sample.id,1)
+
         
         result = crud.add_sample_to_cgmlst_cluster(self.session,'SAM001', cgmlst_cluster_dict)
 
@@ -157,15 +157,12 @@ class TestCrudSample(unittest.TestCase):
         }
 
         created_sample = crud.create_sample(self.session, sample_dict)
-        #self.assertEqual(created_sample.id,1)
         
         result = crud.add_sample_to_cgmlst_cluster(self.session,'SAM001', cgmlst_cluster_dict)
 
         cgmlst_id = crud.get_cgmlst_cluster_by_sample_id(self.session, 'SAM001')
-
         
         self.assertEqual(cgmlst_id,['BC300'])
-        #self.assertEqual(result.id, 2)
 
     def test_delete_sample(self):
         sample_dict = {
@@ -210,9 +207,7 @@ class SampleCrudMachine(RuleBasedStateMachine):
         if created_sample:
             json_serializable_sample = utils.row2dict(created_sample)
             date_fields = [
-                'collection_date',
-                #'valid_until',
-                #'created_at',
+                'collection_date'
             ]
             for date_field in date_fields: 
                 json_serializable_sample[date_field] = str(json_serializable_sample[date_field])
@@ -275,9 +270,7 @@ class CgmlstAlleleProfileCrudMachine(RuleBasedStateMachine):
         if created_sample:
             json_serializable_sample = utils.row2dict(created_sample)
             date_fields = [
-                'collection_date',
-                #'valid_until',
-                #'created_at',
+                'collection_date'
             ]
             for date_field in date_fields: 
                 json_serializable_sample[date_field] = str(json_serializable_sample[date_field])
@@ -326,13 +319,7 @@ class CgmlstAlleleProfileCrudMachine(RuleBasedStateMachine):
         
         created_cgmlst_profile = crud.create_cgmlst_allele_profile(self.session, profile_dict)
         json_serializable_cgmlst_profile = utils.row2dict(created_cgmlst_profile)
-        #date_fields = [
-        #    'valid_until',
-        #    'created_at',
-        #]
-        #for date_field in date_fields: 
-        #    json_serializable_cgmlst_profile[date_field] = str(json_serializable_cgmlst_profile[date_field])
-        #log.debug("Created cgMLST Profile for sample \"" + sample_id + "\": " + json.dumps(json_serializable_cgmlst_profile))
+
 
         note(json_serializable_cgmlst_profile)
         assert(created_cgmlst_profile.sample_id == sample.id)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -44,6 +44,7 @@ class TestCrudSample(unittest.TestCase):
             'sample_id': 'SAM001',
             'accession': 'ACC001',
             'collection_date': datetime.date(1970, 1, 1),
+            
         }
 
         created_sample = crud.create_sample(self.session, sample_dict)
@@ -51,6 +52,39 @@ class TestCrudSample(unittest.TestCase):
         self.assertIsNotNone(created_sample)
         self.assertEqual(created_sample.id, 1)
 
+    def test_get_miru_cluster(self):
+        miru_dict = {
+            'key': 'SAM001',
+            'cluster': 'BC278',
+            'collection_date': datetime.date(1970, 1, 1),
+            'acc_num':'ACC001',
+            'miru_02':'2',
+            'miru_24':'2',
+            'miru_26':'2',
+            'miru_pattern':'123456789'
+        }
+        created_sample = crud.create_miru_profile(self.session,'SAM001', miru_dict)
+        miru_id = crud.get_miru_cluster_by_sample_id(self.session, 'SAM001')
+        self.assertIsNotNone(created_sample)
+        self.assertEqual(miru_id,'BC278')
+
+    def test_get_cgmlst_cluster(self):
+        cgmlst_cluster_dict = {
+            'key': 'SAM001',
+            'cluster': 'BC300'
+        }
+        sample_dict = {
+            'sample_id': 'SAM001',
+            'accession': 'ACC001',
+            'collection_date': datetime.date(1970, 1, 1)            
+        }
+
+        created_sample = crud.create_sample(self.session, sample_dict)
+
+        result = crud.add_sample_to_cgmlst_cluster(self.session,'SAM001', cgmlst_cluster_dict)
+
+        cgmlst_id = crud.get_cgmlst_cluster_by_sample_id(self.session, 'SAM001')
+        self.assertEqual(cgmlst_id,'BC300')
 
     def test_delete_sample(self):
         sample_dict = {

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -105,7 +105,7 @@ class TestCrudSample(unittest.TestCase):
         created_sample = crud.create_miru_profile(self.session,'SAM001', miru_dict)
         miru_id = crud.get_miru_cluster_by_sample_id(self.session, 'SAM001')
         self.assertIsNotNone(created_sample)
-        self.assertEqual(miru_id,'BC278')
+        self.assertEqual(miru_id,['BC278'])
 
     def test_get_cgmlst_cluster(self):
         cgmlst_cluster_dict = {
@@ -126,7 +126,7 @@ class TestCrudSample(unittest.TestCase):
         cgmlst_id = crud.get_cgmlst_cluster_by_sample_id(self.session, 'SAM001')
 
         self.assertIsNotNone(created_sample)
-        self.assertEqual(cgmlst_id,'BC300')
+        self.assertEqual(cgmlst_id,['BC300'])
 
 
     def test_get_miru_cluster(self):
@@ -143,7 +143,7 @@ class TestCrudSample(unittest.TestCase):
         created_sample = crud.create_miru_profile(self.session,'SAM001', miru_dict)
         miru_id = crud.get_miru_cluster_by_sample_id(self.session, 'SAM001')
         self.assertIsNotNone(created_sample)
-        self.assertEqual(miru_id,'BC278')
+        self.assertEqual(miru_id,['BC278'])
 
     def test_get_cgmlst_cluster(self):
         cgmlst_cluster_dict = {
@@ -164,7 +164,7 @@ class TestCrudSample(unittest.TestCase):
         cgmlst_id = crud.get_cgmlst_cluster_by_sample_id(self.session, 'SAM001')
 
         
-        self.assertEqual(cgmlst_id,'BC300')
+        self.assertEqual(cgmlst_id,['BC300'])
         #self.assertEqual(result.id, 2)
 
     def test_delete_sample(self):


### PR DESCRIPTION
This pull request contains the updates for the db after removing the history mixin functionality. The models now have no valid until columns. Samples table has the miru_cluster_id and cgmlst_cluster_id columns removed, instead, it has many to many relationships with miru cluster and cgmlst cluster tables, as specified in the association table.